### PR TITLE
first draft of licensing and archiving chapters

### DIFF
--- a/book/chapters/archiving-and-publishing.qmd
+++ b/book/chapters/archiving-and-publishing.qmd
@@ -1,5 +1,98 @@
 ## Archiving & Publication
 
+### Overview
+
+| Questions | Objectives | Concepts
+| - | - | - |
+| Why would I want to archive my code? | Understand the difference between platforms such as GitHub (distributd version control) & Zenodo (long-term archive) 
+| How does my code become citable? | Understand how to provide citation metadata | CITATION.cff files |
+| How do I make releases of my code? | Understand how to make releases on GitHub | SemVer, CalVer, GitHub Releases |
+| How do I archive my code ? | Enable the GitHub x Zenodo integration and bring the various components together into a workflow | GitHub x Zenodo integration | 
+
+
+### Archiving
+
+Platforms like GitHub, GitLab, Codeberg allow you to make your code findable and accesssible to the public. However, these platforms do not function as long-term archives - there is no guarantee these platforms will still be around in 10 years. 
+
+Archiving your code involves creating a snapshot (in other words, a frozen copy) of your repository at a given point in time and uploading that to an archiving platform such as Zenodo. This process makes your code persistent and citable, particularly because a persistent identifier (PID) will be issued to your code.
+
+### Workflow
+
+#### Enable GitHub x Zenodo Integration
+
+For the workshop, we will use the Zenodo Sandbox - so you can play around with the workflow without actually archiving your sofware.
+
+- Navigate to the Zenodo login page (for today, the Sandbox login)
+- Choose Log In with GitHub -> Authorize Zenodo
+- Once logged in, navigate to your Zenodo x GitHub page (click the profile menu in the header and click GitHub)
+- You will see a list of your repositories (click Sync Now if they haven't appeared)
+- Find the respository you want to archive and toggle the slider to On.
+
+#### CITATION.cff File
+
+The next step in the archiving workflow is to create and/or update your CITATION.cff file.
+
+A CITATION.cff (Citation File Format) file allows you to provide citation metadata about your software that is both human- and machine-readable. GitHub and Zenodo can use the CITATION.cff file to provide (pre-formatted) citation suggestions.
+
+Zenodo implements a subset of the CITATION.cff schema as described in the example below.
+
+```
+cff-version: 1.2.0
+title: "Memory bus simulation scripts"
+version: 1.8.0
+license: "MIT"
+type: software
+abstract: "These are the scripts used to simulate a memory bus"
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: Josiah
+    family-names: Carberry
+    affiliation: Brown University
+    orcid: "https://orcid.org/0000-0002-1825-0097"
+keywords:
+  - computer science
+  - psychoceramics
+  - journaling filesystems
+```
+
+You can validate your CFF files using the following (web)tools:
+- cffinit
+- CFF generator
+
+Don't forget to commit and push your updates to the CITATION.cff file!
+
+#### GitHub Releases
+
+A GitHub Release is a snapshot of your code that you will create at specific points in your repository's development. 
+
+##### Tagging Releases
+
+You can tag (define) your releases using version numbers. Two popular conventions for version numbers are Semantic Versioning (SemVer) and Calendar Versioning (CalVer).
+  - SemVer follows the MAJOR.MINOR.PATCH scheme, with numbers of your choosing. Example: v1.2.3
+  - CalVer follows the MAJOR.MINOR.MICRO scheme, with calendar-based semantics (YYYY/YY, MM/0M, DD/0D). Example: Ubuntu uses year & month for release numbers (YY.0M.MICRO; v24.04.4)
+  
+Check out the websites of SemVer & CalVer and decide which scheme you want to follow.  
+  
+##### Release Workflow
+
+- Go to your repository page on GitHub
+- Click Releases (to the right of the list of files, the right-hand sidebar)
+- Click Draft a new release
+- At this point, you will have to choose a tag. You can create a new tag or use an existing one. Since this is your first release, create a new tag following the SemVer or CalVer schema.
+- The target branch should be main for today's workflow.
+- You can provide a title for your release.
+- Type a description of your release. It is also possible to automatically generate some release notes based on your commits.
+- Publish release.
+- A binary (.zip) file of your code/repository will become available.
+
+#### Finalize Publication Via Zenodo
+
+Only after a repository is enabled through the integration, will Zenodo monitor your repository for releases and assign a DOI. If you created a release before you activated the connection for your repository - it will not be detected and you'll have to make another release.
+
+- Wait for the release to be detected, this might take some time.
+- When details of the release pop up, click the DOI to go to the record.
+- You may need to double-check the citation metadata and make sure Zenodo picked up the right information. Sometimes errors pop up for releases and these are often due to the metadata.
+
 ### Video
 
 {{< video https://vimeo.com/463947879 >}}

--- a/book/chapters/archiving-and-publishing.qmd
+++ b/book/chapters/archiving-and-publishing.qmd
@@ -1,101 +1,232 @@
-## Archiving & Publication
+# Archiving & Publishing: Releases vs. Software Publications
 
-### Overview
+## Overview
 
-| Questions | Objectives | Concepts
-| - | - | - |
-| Why would I want to archive my code? | Understand the difference between platforms such as GitHub (distributd version control) & Zenodo (long-term archive) 
-| How does my code become citable? | Understand how to provide citation metadata | CITATION.cff files |
-| How do I make releases of my code? | Understand how to make releases on GitHub | SemVer, CalVer, GitHub Releases |
-| How do I archive my code ? | Enable the GitHub x Zenodo integration and bring the various components together into a workflow | GitHub x Zenodo integration | 
+| Questions | Objectives | Concepts |
+| --- | --- | --- |
+| Why distinguish between a release and a publication? | Understand the roles of GitHub releases vs. Zenodo archives | Software release, Software publication |
+| How do I create a stable version of my software? | Learn how and when to make a release on GitHub | Version numbers, SemVer, CalVer |
+| How does my code become citable? | Provide citation metadata and archive a release | CITATION.cff, DOI for software |
+| How do I archive my software? | Enable GitHub - Zenodo integration and publish a permanent record | Zenodo integration, Software archiving |
+
+## Why This Matters
+
+In reproducible research, it is not enough to *share* your code. You must also make it:
+
+- **stable** (a version that won’t change)
+- **citable** (with a DOI)
+- **findable** (in a long‑term archive)
+- **reproducible** (others can retrieve the exact version you used)
+
+To achieve this, we distinguish between:
+
+- a **software release** (created on GitHub)  
+- a **software publication** (archived on Zenodo)
+
+These two concepts are related but serve different purposes.
+
+## What Is a Software Release?
+
+A software release is a *snapshot* of your repository at a specific moment in time.  
+It is created on GitHub and is intended for users, collaborators, and developers.
+
+### Characteristics of a Release
+
+- Represents a **stable**, tested version of your software  
+- Uses a version number  
+- Includes release notes describing changes  
+- Can be downloaded as a `.zip` or `.tar.gz`  
+- May still evolve, future releases can follow
+
+### When to Create a Release
+
+A release is appropriate when:
+
+- Your software reaches a **reliable milestone**  
+- You want to communicate a **stable version** to users  
+- You fix major bugs or add significant features  
+- You prepare for a publication or workshop  
+- You want to freeze a version before major refactoring
+
+### Why Releases Matter
+
+Releases help users know:
+
+- which version is stable  
+- which version they should cite  
+- which version matches your documentation  
+- which version is used in a paper or analysis
+
+A release is **not** a long‑term archive.  
+It is a versioned snapshot, but GitHub does not guarantee long‑term preservation.
+
+## A word on Version Numbers
+
+A version number communicates the state, stability, and evolution of your software. It helps users know which version to install, and it supports reproducibility when linking code to publications.
+
+### Two Common Conventions
+
+1. Semantic Versioning (SemVer)
+	Structure:  
+	```
+	MAJOR.MINOR.PATCH
+	```
+
+	- **MAJOR** — breaking changes  
+	- **MINOR** — new features, backwards‑compatible  
+	- **PATCH** — bug fixes only  
+
+	Use SemVer when you want to communicate how safe it is for others to upgrade and when your software is used by others in a stable, predictable way.
+
+2. Calendar Versioning (CalVer)	
+	Structure (common form):  	
+	```
+	YY.MM.MICRO
+	```
+
+	- Based on the **release date**  
+	- Communicates freshness rather than compatibility  
+
+	Use CalVer when your project follows time‑based releases or evolves quickly (e.g., research code, teaching materials).
 
 
-### Archiving
+### When to Use Which
 
-Platforms like GitHub, GitLab, Codeberg allow you to make your code findable and accesssible to the public. However, these platforms do not function as long-term archives - there is no guarantee these platforms will still be around in 10 years. 
+| Situation | Recommended |
+|----------|-------------|
+| Stable library, public API | SemVer |
+| Fast‑moving research code | CalVer |
+| Teaching templates | CalVer |
+| Long‑term maintained package | SemVer |
 
-Archiving your code involves creating a snapshot (in other words, a frozen copy) of your repository at a given point in time and uploading that to an archiving platform such as Zenodo. This process makes your code persistent and citable, particularly because a persistent identifier (PID) will be issued to your code.
+## What Is a Software Publication (Zenodo Archive)?
 
-### Workflow
+A software publication is a *permanent, citable* archived copy of a release.  
+It is stored in a long‑term repository such as **Zenodo**, which issues a **DOI**.
 
-#### Enable GitHub x Zenodo Integration
+### Characteristics of a Software Publication
 
-For the workshop, we will use the Zenodo Sandbox - so you can play around with the workflow without actually archiving your sofware.
+- A frozen, immutable copy of a specific release  
+- Stored in a long‑term archive (Zenodo)  
+- Assigned a persistent identifier (DOI)  
+- Includes citation metadata (from `CITATION.cff`)  
+- Guaranteed to remain accessible for decades
 
-- Navigate to the Zenodo login page (for today, the Sandbox login)
-- Choose Log In with GitHub -> Authorize Zenodo
-- Once logged in, navigate to your Zenodo x GitHub page (click the profile menu in the header and click GitHub)
-- You will see a list of your repositories (click Sync Now if they haven't appeared)
-- Find the respository you want to archive and toggle the slider to On.
+### When to Archive a Release
 
-#### CITATION.cff File
+Archiving is appropriate when:
 
-The next step in the archiving workflow is to create and/or update your CITATION.cff file.
+- You publish a paper, report, or dataset  
+- You need a citable version of your software  
+- Your project is finished or becomes inactive  
+- You want to ensure long‑term preservation 
+- A journal or funder requires a DOI  
+- You want to support reproducibility:  
+  others must retrieve the *exact* version you used
 
-A CITATION.cff (Citation File Format) file allows you to provide citation metadata about your software that is both human- and machine-readable. GitHub and Zenodo can use the CITATION.cff file to provide (pre-formatted) citation suggestions.
+### Why Archiving Matters
 
-Zenodo implements a subset of the CITATION.cff schema as described in the example below.
+Archiving ensures:
 
-```
-cff-version: 1.2.0
-title: "Memory bus simulation scripts"
-version: 1.8.0
-license: "MIT"
-type: software
-abstract: "These are the scripts used to simulate a memory bus"
-message: "If you use this software, please cite it as below."
-authors:
-  - given-names: Josiah
-    family-names: Carberry
-    affiliation: Brown University
-    orcid: "https://orcid.org/0000-0002-1825-0097"
-keywords:
-  - computer science
-  - psychoceramics
-  - journaling filesystems
-```
+- **Permanence**: the version will not disappear  
+- **Citeability**: DOIs are standard in scholarly communication  
+- **Reproducibility**: others can retrieve the exact version  
+- **Compliance**: many journals require archived software
 
-You can validate your CFF files using the following (web)tools:
-- cffinit
-- CFF generator
+## How Releases and Publications Work Together
 
-Don't forget to commit and push your updates to the CITATION.cff file!
+A release and a publication are two steps in one workflow:
 
-#### GitHub Releases
+1. **Create a release on GitHub**  
+   → defines a stable version of your software
 
-A GitHub Release is a snapshot of your code that you will create at specific points in your repository's development. 
+2. **Archive that release on Zenodo**  
+   → makes it permanent and citable
 
-##### Tagging Releases
+This workflow ensures that:
 
-You can tag (define) your releases using version numbers. Two popular conventions for version numbers are Semantic Versioning (SemVer) and Calendar Versioning (CalVer).
-  - SemVer follows the MAJOR.MINOR.PATCH scheme, with numbers of your choosing. Example: v1.2.3
-  - CalVer follows the MAJOR.MINOR.MICRO scheme, with calendar-based semantics (YYYY/YY, MM/0M, DD/0D). Example: Ubuntu uses year & month for release numbers (YY.0M.MICRO; v24.04.4)
+- GitHub handles **development**, **versioning**, **collaboration**  
+- Zenodo handles **preservation**, **metadata**, **DOIs**
+
+They complement each other.
+
+
+## Workflow Summary
+
+To practice follow the steps of the [GitHub Documentation](https://rue-a.github.io/github-zenodo-integration/documentation/).
   
-Check out the websites of SemVer & CalVer and decide which scheme you want to follow.  
-  
-##### Release Workflow
+### 1. Prepare Your Repository
+- Ensure your repository contains:
+  - a clear README
+  - a LICENSE
+  - a CITATION.cff file with correct metadata  
+- Commit and push all changes before creating a release.
 
-- Go to your repository page on GitHub
-- Click Releases (to the right of the list of files, the right-hand sidebar)
-- Click Draft a new release
-- At this point, you will have to choose a tag. You can create a new tag or use an existing one. Since this is your first release, create a new tag following the SemVer or CalVer schema.
-- The target branch should be main for today's workflow.
-- You can provide a title for your release.
-- Type a description of your release. It is also possible to automatically generate some release notes based on your commits.
-- Publish release.
-- A binary (.zip) file of your code/repository will become available.
+### 2. Enable GitHub - Zenodo Integration
+- Log in to Zenodo (or the Zenodo Sandbox for testing).
+- Authorize Zenodo to access your GitHub account.
+- Go to your *GitHub → Zenodo* settings page.
+- Locate your repository and toggle it on.
+- Zenodo will now monitor this repository for new releases.
 
-#### Finalize Publication Via Zenodo
+### 3. Create a Release on GitHub
+- Navigate to *Releases* in your repository.
+- Click *Draft a new release*.
+- Choose a version number (SemVer or CalVer).
+- Add a tag, title and release notes.
+- Publish the release.
 
-Only after a repository is enabled through the integration, will Zenodo monitor your repository for releases and assign a DOI. If you created a release before you activated the connection for your repository - it will not be detected and you'll have to make another release.
+> Zenodo only archives **published releases**, not tags alone.
 
-- Wait for the release to be detected, this might take some time.
-- When details of the release pop up, click the DOI to go to the record.
-- You may need to double-check the citation metadata and make sure Zenodo picked up the right information. Sometimes errors pop up for releases and these are often due to the metadata.
+### 4. Zenodo Detects the Release
+- After publishing, Zenodo automatically:
+  - retrieves the release
+  - creates a new record
+  - assigns a DOI
+- This may take a few minutes.
 
-### Video
+### 5. Review and Finalize the Zenodo Record
+- Open the Zenodo record linked from your release.
+- Check:
+  - title  
+  - authors  
+  - version  
+  - license  
+  - description  
+  - related identifiers (e.g., GitHub URL)
+- Correct any metadata issues.
+- Publish the record.
 
-{{< video https://vimeo.com/463947879 >}}
+> Once published, the archived version becomes **immutable**.
+
+
+### 6. Cite the Software
+- Use the DOI provided by Zenodo.
+- GitHub and Zenodo both read your CITATION.cff file to generate citation text.
+- Include the DOI in:
+  - papers  
+  - reports  
+  - datasets  
+  - documentation 
+
+
+## When to Use What
+
+| Situation | Use a Release | Use a Zenodo Publication |
+|----------|----------------|---------------------------|
+| You want to mark a stable version | ✔️ | |
+| You want users to download a tested version | ✔️ | |
+| You are preparing a workshop or teaching | ✔️ | |
+| You are submitting a paper | | ✔️ |
+| You need a DOI | | ✔️ |
+| You want long‑term preservation | | ✔️ |
+| Your project is finished or inactive | | ✔️ |
+| You want reproducibility for others | ✔️ | ✔️ |
+
+Rule of thumb:
+- A release is for users.  
+- A Zenodo publication is for scholarly citation and preservation.
+
 
 
 ### Slides

--- a/book/chapters/licensing.qmd
+++ b/book/chapters/licensing.qmd
@@ -1,5 +1,25 @@
 # Licensing
 
+## Overview
+
+| Questions | Objectives | Concepts
+| - | - | - |
+| Why do I need to apply a license to my code? | Understand why licenses are necessary for code | Copyright, License |
+| When do I apply a license to my code? | Understand when to apply a license and why | NA |
+| What licenses available for my code? | Awareness of the licenses available | Permissive, Restrictive, Copyleft Licenses |
+
+### Software Licenses
+
+With sofware, copyright is implicit - in other words, your code cannot be (re)used by others without your permission. Applying a license gives that permission, while outlining boundaries and conditions.
+
+You should choose a license early in the project. This compels you to be aware of the terms and conditions of your license as the project proceeds and work accordingly. 
+
+There are numerous licenses available for software. You can use the following license selectors to explore them:
+- <https://ufal.github.io/public-license-selector/>
+- <https://choosealicense.com>
+
+Licenses for software range from restrictive to permissive. There are also copyleft (reciprocal) licenses among these. 
+
 ### Video
 
 {{< video https://vimeo.com/463659936 >}}

--- a/book/chapters/licensing.qmd
+++ b/book/chapters/licensing.qmd
@@ -2,31 +2,128 @@
 
 ## Overview
 
-| Questions | Objectives | Concepts
+| Questions | Objectives | Concepts |
 | - | - | - |
 | Why do I need to apply a license to my code? | Understand why licenses are necessary for code | Copyright, License |
-| When do I apply a license to my code? | Understand when to apply a license and why | NA |
-| What licenses available for my code? | Awareness of the licenses available | Permissive, Restrictive, Copyleft Licenses |
-
-### Software Licenses
-
-With sofware, copyright is implicit - in other words, your code cannot be (re)used by others without your permission. Applying a license gives that permission, while outlining boundaries and conditions.
-
-You should choose a license early in the project. This compels you to be aware of the terms and conditions of your license as the project proceeds and work accordingly. 
-
-There are numerous licenses available for software. You can use the following license selectors to explore them:
-- <https://ufal.github.io/public-license-selector/>
-- <https://choosealicense.com>
-
-Licenses for software range from restrictive to permissive. There are also copyleft (reciprocal) licenses among these. 
-
-### Video
-
-{{< video https://vimeo.com/463659936 >}}
+| When do I apply a license to my code? | Understand when to apply a license and why | — |
+| What licenses are available for my code? | Awareness of the licenses available | Permissive, Restrictive, Copyleft |
 
 
-### Slides
+## Why Licenses Matter for Research Software
 
+Software is automatically protected by copyright the moment you create it.  
+This means:
+
+- **No one is legally allowed to use, modify, or share your code** unless you explicitly grant permission.
+- Even well‑intentioned collaborators, students, or other researchers cannot reuse your work without a license.
+- Journals, research institutes, and open‑science platforms increasingly require a clear license before accepting software.
+
+A license is therefore not just a legal formality, it is a **prerequisite for reproducibility**.  
+Without a license, your code cannot be reused, validated, or extended by others, which undermines the entire purpose of sharing research software.
+
+Licensing also protects *you*:
+
+- It clarifies what others may do with your work.
+- It shields you from liability.
+- It prevents misunderstandings about ownership and reuse.
+- It ensures your contributions are acknowledged.
+
+## Why You Should Choose a License Early
+
+Choosing a license at the beginning of a project is important because:
+
+- It sets expectations for collaborators from day one.
+- It avoids conflicts when contributions accumulate under unclear terms.
+- It prevents incompatible dependencies (e.g., mixing GPL and non‑GPL code).
+- It ensures compliance with institutional or funder requirements.
+- It avoids painful retroactive decisions, such as needing permission from every contributor to change the license later.
+
+Early licensing is part of good research hygiene, just like version control, documentation, and folder structure.
+
+
+## Data and Software Licenses
+
+Software and data serve different purposes and therefore require **different types of licenses**:
+
+- **Software licenses** (MIT, GPL, Apache 2.0)  
+  - Govern *use, modification, and redistribution* of code  
+  - Often include clauses about derivative works, attribution, and liability  
+  - May impose “[copyleft](https://en.wikipedia.org/wiki/Copyleft)” requirements (e.g., GPL)
+
+- **Data licenses** (CC‑BY, CC0, ODbL)  
+  - Govern *access, reuse, and sharing* of datasets  
+  - Focus on attribution, privacy, and ethical reuse  
+  - Do **not** impose copyleft on software using the data
+
+Key differences:
+
+- Software licenses regulate **functional artifacts** (code that executes).  
+- Data licenses regulate **informational artifacts** (facts, measurements, text, images).  
+- Software licenses may require derivative works to adopt the same license;  
+  data licenses generally do not.  
+- Data may contain **sensitive or personal information**, requiring additional restrictions.
+
+For more detail, see:  
+<https://book.the-turing-way.org/reproducible-research/licensing/licensing-data/>
+
+## Types of Software Licenses
+
+There are many software licenses, but they generally fall into three categories:
+
+- **Permissive licenses** (MIT, BSD, Apache 2.0)  
+  Allow reuse with minimal restrictions.
+
+- **Copyleft licenses** (GPL, AGPL, LGPL)  
+  Require derivative works to use the same license.
+
+- **Restrictive / proprietary licenses**  
+  Limit reuse and redistribution.
+
+To explore options, use:
+
+- [https://ufal.github.io/public-license-selector/](https://ufal.github.io/public-license-selector/)  
+- [https://choosealicense.com](https://choosealicense.com)
+
+
+## Changing a License Later: What to Consider
+
+Changing a license is possible, but not always straightforward.  
+Before doing so, you must consider:
+
+### 1. Who owns the copyright?
+If your project has multiple contributors, **you must obtain permission from all of them** to change the license.  
+Every contributor owns the copyright to their contributions unless they have signed a Contributor License Agreement (CLA).
+
+If you cannot reach all contributors, you may be unable to relicense the project.
+
+### 2. Are there external dependencies?
+Some licenses are **incompatible** with others.  
+For example:
+
+- GPL code cannot be relicensed under MIT without removing or replacing the GPL components.
+- Apache 2.0 and GPLv2 are incompatible.
+
+Changing your license may require restructuring your codebase.
+
+### 3. What about downstream users?
+If others have already used or forked your code:
+
+- They may continue using it under the **old license**.
+- Your new license applies only to **future versions**.
+
+### 4. Institutional or funder requirements
+Some institutions mandate specific licenses (e.g., Apache 2.0 for government-funded work).  
+Changing the license may require approval.
+
+### 5. Documentation and communication
+If you decide to change the license:
+
+- Update `LICENSE.md`
+- Update `README.md`
+- Add a note in the changelog or release notes
+- Communicate the change clearly to users and contributors
+
+## Slides
 
 ```{=html}
 <iframe class="slide-deck" src="../slides/slides_licensing.html" title="Licensing" width="960" height="540">
@@ -34,10 +131,11 @@ Licenses for software range from restrictive to permissive. There are also copyl
 ```
 
 
-### Exercise
+## Exercise
 
-* Check the license in your project
-
-* Take a look at other license options via [choosealicense.com](https://choosealicense.com/).
-
-* Do you want to change your license? Go into your Github and change the LICENSE.md file. Don't forget to pull your remote changes!
+- Check the license in your project.
+- Explore alternatives via [choosealicense.com](https://choosealicense.com/).
+- If you want to change your license:
+  - Update the `LICENSE.md` file in your GitHub repository.
+  - Commit and push the change.
+  - Make sure the new license is compatible with your dependencies and contributions.

--- a/book/slides/slides_archiving_publishing.qmd
+++ b/book/slides/slides_archiving_publishing.qmd
@@ -1,5 +1,5 @@
---- 
-format: 
+---
+format:
   revealjs:
     margin: 0
     theme: ../styles/uu.scss
@@ -7,164 +7,205 @@ format:
     footer: "Workshop Computational Reproducibility"
 ---
 
-# Archiving and Publication {data-background-color="#FFCD00"}
+# Archiving & Publishing  {data-background-color="#FFCD00"}
 
-## Let's think about the future... {.scrollable }
-::: {.theme-section}
 
-::: {.fragment fragment-index=1}
-
-
-- Will this repository still be here in five years? 
-
-
-
-- #### Will my account? 
-
-
-
-- ### Will GitHub?
-:::
-:::
-
-## Publishing and archiving
-
-::: {.theme-section}
-
-:::::::::::::: {.columns}
-
-::: {.column width="80%"}
-
-- Frozen version of the current state of your code repository.
-
-- You will get an *actual* DOI, and your project will (probably?) not be deleted!
-
-- You can only publish public repositories with Zenodo.
-
-- Only do this following exercise if you are OK with your code staying online!
-
-
-Zenodo and Github have a pipeline that makes your life easier! (_Check the full how-to [on GitHub](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content#issuing-a-persistent-identifier-for-your-repository-with-zenodo)._)
-
-
-#### Demo or follow along:
-
-- Make sure you have a test repository on GitHub!
-
-- Go to: [sandbox.zenodo.org](https://sandbox.zenodo.org/), and log in with GitHub. (If you do not have GitHub, simply sign up for a zenodo account; some of the coming steps you will need to do manually...)
-- GitHub will then ask permission to give Zenodo access; click "Authorize application".
-
-:::
-::: {.column width="20%"}
-![](https://blog.zenodo.org/static/img/logos/zenodo-gradient-1000.png){ width="300" fig-align="center"}
-
-
-:::
-::::::::::::::
-:::
-
-## Select your repository
-
-::: {.theme-section}
-
-- On Zenodo, click on your user name and select "GitHub".
-
-![](https://web.archive.org/web/20211021121037if_/https://guides.github.com/activities/citable-code/zenodo-toggle-on.png){ width="90%" height="600" fig-align="center"}
-
-Click on your enabled repository. This will take you to a page with a green GitHub button. With this button you can create a release for your publication.
-
-:::
-
-## Release your project!
-
-::: {.theme-section}
-
-![](https://web.archive.org/web/20211026201828if_/https://guides.github.com/activities/citable-code/repo-view.png){ width="60%" fig-align="center" height="500"}
-
-... and follow the workflow!
-
-(Unsure about version number? Wait a slide! :-)
-
-:::
-
-## Semantic versioning
-
-::: {.theme-section}
-
-A version has three numbers: MAJOR.MINOR.PATCH
-
-- MAJOR version denotes changes that alter the compatibility (i.e. someone using your functions may need to change their use for their code to still work),
-- MINOR version adds functionality, but remains compatible
-- PATCH version makes (compatible) bug fixes.
-
-(If your bug fix changes compatibility, it is therefore a MAJOR version change!)
-
-
-**You can release today with v0.1.0**
-:::
-
-## Check Zenodo
-
-::: {.theme-section}
-
-Your code is now uploading to Zenodo: you can check it under the 'upload' tab:
-
-![](https://web.archive.org/web/20211026201828if_/https://guides.github.com/activities/citable-code/upload-tab.png){ width="70%" height="600" fig-align="center"}
-
-:::
-
-## Getting your DOI
-
-::: {.theme-section}
-
-- Add some final descriptions
-- Click 'publish'
-- Voilá!
-
-![](https://web.archive.org/web/20211026201828if_/https://guides.github.com/activities/citable-code/zenodo-form.png){ width="70%" height="500" fig-align="center"}
-
-:::
-
-## Getting your DOI
-
-::: {.theme-section}
-
-Do you know your DOI?
-<br><br>
-
-As a final touch (only with real Zenodo!): you can take your DOI and place it as a badge at the top of your README.
-<br><br>
-
-
-```bash
-[![DOI](https://zenodo.org/badge/doi/YOUR.DOI.svg)](http://dx.doi.org/YOUR.DOI)
-```
-
-<br><br>
-
-
-
-__This is not recommended with a Sandbox DOI, because sandbox projects are not permanent.__
-__The Sandbox DOI will not work like a normal one does!__
-
-:::
-
-## Are you ready? {.scrollable }
+## Let's think about the future… {.scrollable}
 
 ::: {.theme-section}
 
 ::: {.fragment fragment-index=1}
-**Let's exchange projects!**
+- Will this repository still be here in five years?
+:::
 
-Find one of your neighbours and exchange the URLs to your GitHub repository.
-
+::: {.fragment fragment-index=2}
+- Will *my account* still be here?
 :::
 
 ::: {.fragment fragment-index=3}
-
-**As you reproduce, please give your colleague feedback!**
-
-Open an issue in your colleague's GitHub repository and copy/paste this [feedback template](https://github.com/UtrechtUniversity/workshop-computational-reproducibility/blob/main/feedback-on-reproducing-projects.txt)
+- Will GitHub still exist in its current form?
+:::
 
 :::
+
+## Why Archiving Matters
+
+::: {.theme-section}
+
+- GitHub is **not** a long‑term archive.  
+- Repositories can be deleted, accounts can disappear, platforms can change.
+- For reproducible research, we need:
+  - **stability** (a version that won’t change)
+  - **citeability** (a DOI)
+  - **findability** (persistent identifier)
+  - **reproducibility** (retrieve the exact version used)
+
+To achieve this, we distinguish between:
+
+- a **software release** (GitHub)  
+- a **software publication** (Zenodo)
+
+:::
+
+
+## What Is a Software Release?
+
+::: {.theme-section}
+
+A software release is a *snapshot* of your repository at a specific moment in time.
+<div style="margin-bottom: 50px;"></div>
+:::: {.columns}
+
+::: {.column width="50%"}
+
+**Characteristics**
+
+- Stable, tested version  
+- Has a **version number**  
+- Includes release notes  
+- Downloadable as `.zip` or `.tar.gz`  
+- May evolve, future releases can follow  
+:::
+
+::: {.column width="50%"}
+**When to create a release**
+
+- Reaching a reliable milestone  
+- Preparing a workshop or teaching  
+- Fixing major bugs or adding features  
+- Freezing a version before refactoring 
+:::
+
+::::
+
+<div style="margin-bottom: 50px;"></div>
+
+A release is **not** a long‑term archive.
+
+:::
+
+## A Word on Version Numbers
+
+::: {.theme-section}
+
+- A version number communicates the **state**, **stability**, and **evolution** of your software.
+
+- Two common conventions
+
+:::: {.columns}
+
+::: {.column width="50%"}
+**Semantic Versioning (SemVer)** 
+```
+MAJOR.MINOR.PATCH
+```
+- MAJOR — breaking changes  
+- MINOR — new features, compatible  
+- PATCH — bug fixes  
+
+Use when you want to signal how safe it is for others to upgrade.
+:::
+
+::: {.column width="50%"}
+**Calendar Versioning (CalVer)**
+```
+YY.MM.MICRO
+```
+- Based on release date  
+- Emphasises freshness  
+
+Use for fast‑moving research code or teaching materials.
+
+:::
+
+::::
+:::
+
+
+## What Is a Software Publication?
+
+::: {.theme-section}
+
+A software publication is a *permanent, citable* archived copy of a release.
+<div style="margin-bottom: 100px;"></div>
+:::: {.columns}
+
+::: {.column width="50%"}
+**Characteristics**
+
+- Frozen, immutable version  
+- Stored in a long‑term archive (Zenodo)  
+- Assigned a **DOI**  
+- Includes citation metadata (`CITATION.cff`)  
+- Guaranteed long‑term accessibility 
+:::
+
+::: {.column width="50%"}
+**When to archive a release**
+
+- Publishing a paper or report  
+- Project is finished or inactive  
+- Reproducibility is required  
+- A journal or funder requires a DOI 
+:::
+
+::::
+
+
+
+:::
+
+## Workflow Overview
+
+::: {.theme-section}
+<div style="transform: scale(1.4); transform-origin: top center;">
+```{mermaid}
+%%| fig-align: center
+%%{init: {
+  "theme": "forest",
+  "look": "handDrawn",
+  "flowchart": { "htmlLabels": false }
+}}%%
+flowchart LR
+    A[Prepare repo] --> B[Enable integration]
+    B --> C[Create release]
+    C --> D[Zenodo detects]
+    D --> E[Review record]
+    E --> F[Cite software]
+```
+</div>
+
+<div style="margin-bottom: 100px;"></div>
+**Prepare repo:** README, LICENSE, CITATION.cff  
+**Enable integration:** Log in to Zenodo · Authorize GitHub · Toggle repo ON  
+**Create release:** Choose version number · Add notes · Publish  
+**Zenodo detects:** Creates record · Assigns DOI  
+**Review record:** Check metadata · Publish archive  
+**Cite software:** Use DOI · CITATION.cff provides citation text
+
+**Exercise (optional)**
+
+Follow the workflow outlined in this guide to archive your code to Zenodo. Use the Sandbox version of Zenodo to make sure your repository is not actually archived permanently!
+
+:::
+
+
+## Are you ready? {.scrollable}
+
+::: {.theme-section}
+
+::: {.fragment fragment-index=1}
+**Exchange projects!**  
+Share your GitHub repository with a neighbour.
+:::
+
+::: {.fragment fragment-index=2}
+Try to reproduce each other’s project.
+:::
+
+::: {.fragment fragment-index=3}
+Open an issue in their repository using the  
+[feedback template](https://github.com/UtrechtUniversity/workshop-computational-reproducibility/blob/main/feedback-on-reproducing-projects.txt)
+:::
+
 :::

--- a/book/slides/slides_licensing.qmd
+++ b/book/slides/slides_licensing.qmd
@@ -1,5 +1,5 @@
---- 
-format: 
+---
+format:
   revealjs:
     margin: 0
     theme: ../styles/uu.scss
@@ -9,19 +9,100 @@ format:
 
 # Licensing {data-background-color="#FFCD00"}
 
-## Choosing a license 
+
+## Why Licensing Matters
 
 ::: {.theme-section}
 
-- There are over [80 OSI-approved licenses](https://opensource.org/licenses/alphabetical) (and [many](http://dbad-license.org), [many](http://www.wtfpl.net) others) to choose from.
+- Software is automatically protected by **copyright**: Others *cannot* reuse your code without explicit permission.
+- A license grants that permission and defines **boundaries**, **conditions**, and **responsibilities**.
+- Licensing is essential for:
+  - Reproducibility: others must be able to run and inspect your code.
+  - Collaboration: colleagues need clarity on what they may do.
+  - Open Science: journals and funders increasingly require a clear license.
+  - Protecting yourself: licenses limit liability and ensure attribution.
 
-The MIT license is recommended by Utrecht University:
+> Without a license, your code is *not legally reusable*, even if it is public on GitHub.
 
-![](../images/screenshots/license.png){  width="60%" fig-align="center"}
+:::
 
-What is important to you? What does your lab use?
 
-Let's take a look at a [license selector](https://ufal.github.io/public-license-selector/).
+## Choose a License Early
+
+::: {.theme-section}
+
+Choosing a license at the start of your project:
+
+- Sets expectations for collaborators.
+- Prevents incompatible contributions (e.g., GPL vs. MIT).
+- Avoids legal or administrative issues later.
+- Ensures compliance with institutional or funder requirements.
+- Saves you from needing to re‑contact contributors later.
+
+Early licensing is part of good research hygiene like documentation, folder structure, and version control.
+
+:::
+
+## Choosing a License
+
+::: {.theme-section}
+
+- There are over [80 OSI-approved licenses](https://opensource.org/licenses/alphabetical)  
+  (and [many](http://dbad-license.org), [many](http://www.wtfpl.net) others).
+
+Utrecht University recommends the **MIT License**:
+
+![](../images/screenshots/license.png){width="80%" fig-align="center"}
+
+What is important to you?  
+What does your lab use?
+
+Try a license selector:  
+<https://ufal.github.io/public-license-selector/>
+
+:::
+
+## Types of Software Licenses
+
+::: {.theme-section}
+
+- **Permissive licenses** (MIT, BSD, Apache 2.0)  
+  Few restrictions; widely used in research.
+
+- **Copyleft licenses** (GPL, AGPL, LGPL)  
+  Derivative works must use the same license.
+
+- **Restrictive / proprietary licenses**  
+  Limit reuse and redistribution.
+
+Explore options via:  
+<https://choosealicense.com>
+
+:::
+
+## Changing a License Later
+
+::: {.theme-section}
+
+Changing a license is possible, but requires care:
+
+- **Copyright ownership**  
+  You must obtain permission from *all contributors* unless a CLA is in place.
+
+- **Dependency compatibility**  
+  Some licenses cannot be mixed (e.g., GPL code cannot be relicensed as MIT).
+
+- **Downstream users**  
+  Past versions remain under the old license; the new license applies only to future releases.
+
+- **Institutional or funder requirements**  
+  Some projects must use specific licenses.
+
+If you change your license:
+
+- Update `LICENSE.md`
+- Update `README.md`
+- Document the change in release notes or CHANGELOG
 
 :::
 
@@ -31,9 +112,46 @@ Let's take a look at a [license selector](https://ufal.github.io/public-license-
 
 - There are different licenses for software and data.
 - Separate code and software publications from data publications.
-- Link software and data through their DOIs
-- Create manuals in your README how to get and run your software on the published data.
+- Link software and data through their DOIs.
+- Provide clear instructions in your README:
+  - how to obtain the data  
+  - how to run the software on the published dataset  
 
-Please read the guide about [Data Licenses and Licenses for AI Models](https://book.the-turing-way.org/reproducible-research/licensing/licensing-data/).
+For more detail:  
+<https://book.the-turing-way.org/reproducible-research/licensing/licensing-data/>
+
+:::
+
+## How Software and Data Licenses Differ
+
+::: {.theme-section}
+
+Software and data serve different purposes and therefore require **different types of licenses**:
+
+:::: {.columns}
+
+::: {.column width="50%"}
+**Software licenses** (MIT, GPL, Apache 2.0)
+
+- Regulate *use, modification, and redistribution* of code  
+- Often include rules about derivative works and copyleft  
+- May impose obligations on downstream software
+:::
+
+::: {.column width="50%"}
+**Data licenses** (CC‑BY, CC0, ODbL)  
+
+- Regulate *access, reuse, and sharing* of datasets  
+- Focus on attribution, ethical reuse, and privacy  
+- Do **not** impose copyleft on software that uses the data
+:::
+::::
+
+**Key differences:**
+
+- Software licenses govern **functional artifacts** (code that executes).  
+- Data licenses govern **informational artifacts** (facts, measurements, text, images).  
+- Software licenses may require derivative works to adopt the same license
+- Data may contain sensitive or personal information, requiring additional restrictions.
 
 :::


### PR DESCRIPTION
Hellohello! I've drafted some text for the licensing and archiving chapters.

- The text for licensing is pretty limited at the moment, let me me know if there should be more text to elaborate on the concepts.

- The text for archiving is a little messy, but all the necessary concepts are covered. I'm not sure how you teach the workflow these days, I started off with enabling the GitHub x Zenodo integration and then going back to GitHub to work on the CITATION.cff files and making a release. Then you go back to Zenodo and hopefully see the release pop up. I would rather not have to switch between GitHub & Zenodo, but it seems better than making a release twice?

- I put more information about CITATION.cff files, Semantic Versioning & Calendar Versioning, GitHub Releases. There are no screenshots at the moment, I would like to finalize the text and flow first. The same goes for links and references.

- I can update the slides when we have a direction on the text. 